### PR TITLE
feat: 添加 Spotify API 集成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config
 myinfo.json
 youtube_tokens.json
 platforms/youtube/youtube_tokens.json
+platforms/spotify/spotify_tokens.json
 
 # IDE and editor files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ A unified personal data hub built on MCP (Model Context Protocol) that allows AI
 - Get following list and user-uploaded videos
 - Browse "to view later" list and personal collections
 
+### 🎵 Spotify Integration
+- Complete OAuth2 authentication with automatic token management
+- Get user profile and music library data
+- Access top artists, tracks, and recently played music
+- Social features: follow/unfollow artists and playlists
+- Library management: saved tracks, albums, shows, episodes, audiobooks
+- Playlist operations: view and manage personal playlists
+
 ## 📦 Installation and Setup
 
 ### 1. Install Dependencies
@@ -153,6 +161,23 @@ BILIBILI_BILI_JCT=your_bilibili_bili_jct_cookie
 BILIBILI_BUVID3=your_bilibili_buvid3_cookie
 ```
 
+### 🎵 Spotify API Setup
+
+> 📖 **Detailed setup guide**: [platforms/spotify/README.md](platforms/spotify/README.md) | [中文指南](platforms/spotify/README_zh.md)
+
+**Quick summary**: 
+1. Create a Spotify app in [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+2. Configure redirect URIs in your app settings
+3. Use MCP tools for OAuth2 authentication with automatic token management
+
+**Configuration:**
+```bash
+SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
+SPOTIFY_REDIRECT_URI=https://example.com/callback
+# OAuth2 tokens are managed automatically after authentication
+```
+
 ## 🖥️ Cursor Configuration
 
 Add the MCP server to your Cursor settings:
@@ -234,20 +259,6 @@ This system implements intelligent YouTube OAuth2 token management with the foll
 2. **Auto-refresh tokens from token file** (Recommended method)
 3. **Tokens from environment variables** (Backup method)
 
-### 📁 File Descriptions
-- `youtube_tokens.json` - Automatically generated and maintained token file
-- `youtube_oauth_helper.py` - OAuth2 authentication helper script
-- `auto_refresh_youtube_token.py` - Manual token refresh tool
-
-### 🛠️ Usage
-```bash
-# Initial OAuth2 token setup
-cd platforms/youtube
-python3 youtube_oauth_helper.py
-
-# Manual token refresh (optional)
-python3 auto_refresh_youtube_token.py
-```
 
 The system automatically handles all token management - no manual maintenance required!
 
@@ -288,12 +299,34 @@ The system automatically handles all token management - no manual maintenance re
 - `get_bilibili_coin_videos()` - Get videos you've given coins to
 - `get_bilibili_toview_list()` - Get your "to view later" list
 
+### 🎵 Spotify Tools (17 Total)
+
+**Authentication & Configuration (7 tools):**
+- `test_spotify_credentials()` - Test API credentials
+- `setup_spotify_oauth()` - Initialize OAuth flow
+- `complete_spotify_oauth()` - Complete OAuth authentication
+- `get_spotify_token_status()` - Get token status
+- `refresh_spotify_token()` - Manual token refresh
+
+**Music Discovery & Social (9 tools):**
+- `get_current_user_profile()` - Get your Spotify profile
+- `get_user_top_items()` - Get top artists/tracks
+- `get_user_recently_played()` - Get recently played music
+- `get_followed_artists()` - Get followed artists
+- `follow_artists_or_users()` / `unfollow_artists_or_users()` - Social features
+
+**Library & Playlists (6 tools):**
+- `get_user_saved_tracks()` / `get_user_saved_albums()` - Library management
+- `get_user_saved_shows()` / `get_user_saved_episodes()` - Podcast content
+- `get_current_user_playlists()` / `get_playlist_items()` - Playlist operations
+
 ### 🔧 System Tools
 - `test_connection()` - Test if MCP server is working
 - `get_personalization_status()` - Get overall platform status
 - `test_steam_credentials()` - Test Steam API configuration
 - `test_youtube_credentials()` - Test YouTube API configuration
 - `test_bilibili_credentials()` - Test Bilibili configuration
+- `test_spotify_credentials()` - Test Spotify API configuration
 
 ## 💬 Usage Examples
 
@@ -313,6 +346,12 @@ The system automatically handles all token management - no manual maintenance re
 - "Analyze my gaming habits and preferences"
 - "What type of YouTube content do I watch most?"
 - "Show me my Bilibili favorites and liked videos"
+
+### Music & Audio Analysis
+- "What artists have I been listening to most lately on Spotify?"
+- "Show me my recently played music and find patterns"
+- "What are my top tracks from the past month?"
+- "Find new music recommendations based on my Spotify data"
 
 ## 🚀 Development
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -87,6 +87,14 @@
 - 获取关注列表和用户上传的视频
 - 浏览"稍后再看"列表和个人收藏
 
+### 🎵 Spotify 集成
+- 完整的 OAuth2 认证和自动令牌管理
+- 获取用户档案和音乐库数据
+- 访问热门艺术家、曲目和最近播放的音乐
+- 社交功能：关注/取消关注艺术家和播放列表
+- 音乐库管理：保存的曲目、专辑、节目、单集、有声读物
+- 播放列表操作：查看和管理个人播放列表
+
 ## 📦 安装和设置
 
 ### 1. 安装依赖
@@ -205,6 +213,23 @@ BILIBILI_BUVID3=your_bilibili_buvid3_cookie
 - Bilibili cookies 会定期过期，需要更新
 - 请保护好这些 cookies，因为它们提供对你个人 Bilibili 数据的访问权限
 - 不要公开分享这些 cookies
+
+### 🎵 Spotify API 设置
+
+> 📖 **详细设置指南**：[platforms/spotify/README.md](platforms/spotify/README.md) | [中文指南](platforms/spotify/README_zh.md)
+
+**快速总结**：
+1. 在 [Spotify 开发者控制台](https://developer.spotify.com/dashboard) 创建 Spotify 应用
+2. 在应用设置中配置重定向 URI
+3. 使用 MCP 工具进行 OAuth2 认证和自动令牌管理
+
+**配置：**
+```bash
+SPOTIFY_CLIENT_ID=your_spotify_client_id_here
+SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
+SPOTIFY_REDIRECT_URI=https://example.com/callback
+# OAuth2 令牌在认证后自动管理
+```
 
 ## 🖥️ Cursor 配置
 
@@ -342,12 +367,34 @@ python3 auto_refresh_youtube_token.py
 - `get_bilibili_coin_videos()` - 获取你投币的视频
 - `get_bilibili_toview_list()` - 获取你的"稍后再看"列表
 
+### 🎵 Spotify 工具（共 17 个）
+
+**认证和配置工具（7 个）：**
+- `test_spotify_credentials()` - 测试 API 凭据
+- `setup_spotify_oauth()` - 初始化 OAuth 流程
+- `complete_spotify_oauth()` - 完成 OAuth 认证
+- `get_spotify_token_status()` - 获取令牌状态
+- `refresh_spotify_token()` - 手动刷新令牌
+
+**音乐发现和社交工具（9 个）：**
+- `get_current_user_profile()` - 获取你的 Spotify 档案
+- `get_user_top_items()` - 获取热门艺术家/曲目
+- `get_user_recently_played()` - 获取最近播放的音乐
+- `get_followed_artists()` - 获取关注的艺术家
+- `follow_artists_or_users()` / `unfollow_artists_or_users()` - 社交功能
+
+**音乐库和播放列表工具（6 个）：**
+- `get_user_saved_tracks()` / `get_user_saved_albums()` - 音乐库管理
+- `get_user_saved_shows()` / `get_user_saved_episodes()` - 播客内容
+- `get_current_user_playlists()` / `get_playlist_items()` - 播放列表操作
+
 ### 🔧 系统工具
 - `test_connection()` - 测试 MCP 服务器是否正常工作
 - `get_personalization_status()` - 获取整体平台状态
 - `test_steam_credentials()` - 测试 Steam API 配置
 - `test_youtube_credentials()` - 测试 YouTube API 配置
 - `test_bilibili_credentials()` - 测试 Bilibili 配置
+- `test_spotify_credentials()` - 测试 Spotify API 配置
 
 ## 💬 使用示例
 
@@ -367,6 +414,12 @@ python3 auto_refresh_youtube_token.py
 - "分析我的游戏习惯和偏好"
 - "我最常看什么类型的 YouTube 内容？"
 - "显示我的 Bilibili 收藏和点赞视频"
+
+### 音乐和音频分析
+- "我最近在 Spotify 上最常听哪些艺术家？"
+- "显示我的播放模式并发现音乐偏好"
+- "我这个月的热门曲目是什么？"
+- "基于我的 Spotify 数据寻找新的音乐推荐"
 
 ## 🚀 开发
 

--- a/platforms/spotify/README.md
+++ b/platforms/spotify/README.md
@@ -1,0 +1,168 @@
+# Spotify Platform Integration
+
+This module provides comprehensive Spotify API integration for PersonalHub, allowing access to personal music data, preferences, and user interactions.
+
+## Features
+
+- ✅ **Complete OAuth2 authentication** with automatic token refresh
+- ✅ **User profile and library management** 
+- ✅ **Music discovery** - top artists, tracks, and recently played
+- ✅ **Social features** - follow/unfollow artists and playlists
+- ✅ **Library management** - saved tracks, albums, shows, episodes, audiobooks
+- ✅ **Playlist operations** - view and manage playlists
+- ✅ **Seamless token management** - no manual refresh needed
+
+## Setup
+
+### 1. Create Spotify App
+
+1. Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+2. Create a new app
+3. Configure redirect URIs in your app settings
+4. Note down your Client ID and Client Secret
+
+### 2. Configure Environment Variables
+
+Add the following to your config file:
+
+```bash
+# Spotify API Configuration
+SPOTIFY_CLIENT_ID=your_client_id_here
+SPOTIFY_CLIENT_SECRET=your_client_secret_here
+SPOTIFY_REDIRECT_URI=https://example.com/callback
+```
+
+### 3. Complete OAuth Authentication
+
+Use the MCP tools to complete OAuth authentication:
+
+```bash
+# Step 1: Initialize OAuth flow
+setup_spotify_oauth client_id="your_client_id" client_secret="your_client_secret"
+
+# Step 2: Visit the provided authorization URL and authorize the app
+# Step 3: Copy the authorization code from the callback URL
+
+# Step 4: Complete authentication
+complete_spotify_oauth client_id="your_client_id" client_secret="your_client_secret" authorization_code="your_auth_code"
+```
+
+## Available MCP Tools (17 Total)
+
+### 🔐 Authentication & Configuration (7 tools)
+- `test_spotify_credentials()` - Test API credentials
+- `get_spotify_config()` - Get configuration status
+- `setup_spotify_oauth(client_id, client_secret, redirect_uri?)` - Initialize OAuth flow
+- `complete_spotify_oauth(client_id, client_secret, authorization_code, redirect_uri?)` - Complete OAuth authentication
+- `refresh_spotify_token()` - Manually refresh access token
+- `auto_refresh_spotify_token_if_needed()` - Auto-refresh if needed
+- `get_spotify_token_status()` - Get token status information
+
+### 👤 User Profile (2 tools)
+- `get_current_user_profile(access_token?)` - Get current user's profile
+- `get_user_profile(user_id, access_token?)` - Get specific user's profile
+
+### 🎵 Music Discovery (2 tools)
+- `get_user_top_items(item_type="tracks", time_range="medium_term", limit=50, access_token?)` - Get top artists or tracks
+- `get_user_recently_played(limit=50, access_token?)` - Get recently played tracks
+
+### 👥 Social Features (5 tools)
+- `get_followed_artists(limit=50, access_token?)` - Get followed artists
+- `follow_artists_or_users(ids, follow_type="artist", access_token?)` - Follow artists/users
+- `unfollow_artists_or_users(ids, follow_type="artist", access_token?)` - Unfollow artists/users
+- `follow_playlist(playlist_id, public=true, access_token?)` - Follow a playlist
+- `unfollow_playlist(playlist_id, access_token?)` - Unfollow a playlist
+
+### 💾 Library Management (5 tools)
+- `get_user_saved_tracks(limit=50, offset=0, access_token?)` - Get saved tracks
+- `get_user_saved_albums(limit=50, offset=0, access_token?)` - Get saved albums
+- `get_user_saved_shows(limit=50, offset=0, access_token?)` - Get saved podcast shows
+- `get_user_saved_episodes(limit=50, offset=0, access_token?)` - Get saved podcast episodes
+- `get_user_saved_audiobooks(limit=50, offset=0, access_token?)` - Get saved audiobooks
+
+### 📋 Playlist Operations (3 tools)
+- `get_current_user_playlists(limit=50, offset=0, access_token?)` - Get current user's playlists
+- `get_user_playlists(user_id, limit=50, offset=0, access_token?)` - Get user's public playlists
+- `get_playlist_items(playlist_id, limit=100, offset=0, access_token?)` - Get playlist contents
+
+## OAuth Scopes
+
+The following scopes are automatically requested during authentication:
+
+**Read Permissions:**
+- `user-read-private` - Access to user's profile information
+- `user-read-email` - Access to user's email address
+- `user-library-read` - Access to user's saved content
+- `user-read-recently-played` - Access to recently played tracks
+- `user-top-read` - Access to top artists and tracks
+- `playlist-read-private` - Access to private playlists
+- `playlist-read-collaborative` - Access to collaborative playlists
+- `user-read-playback-state` - Access to current playback state
+- `user-read-currently-playing` - Access to currently playing track
+
+**Follow Permissions:**
+- `user-follow-read` - Access to followed artists and users
+- `user-follow-modify` - Ability to follow/unfollow artists and users
+
+**Playlist Permissions:**
+- `playlist-modify-public` - Ability to modify public playlists
+- `playlist-modify-private` - Ability to modify private playlists
+
+## Automatic Token Management
+
+✅ **Access tokens automatically refresh** before expiration (every ~55 minutes)
+✅ **Refresh tokens valid for 1 year** and auto-extend with each use
+✅ **No manual intervention required** - completely automated
+✅ **Seamless background operation** - users never see token expiration
+
+### Only re-authentication needed when:
+- Refresh token expires (after ~1 year of no use)
+- User manually revokes app permissions
+- App permissions/scopes are modified
+
+## Default Limits (Optimized for Maximum Data)
+
+All tools use **maximum allowed limits** by default:
+- **Most APIs**: 50 items (API maximum)
+- **Playlist contents**: 100 items (API maximum)
+- **Pagination**: All tools support `offset` parameter for additional data
+
+## File Structure
+
+```
+spotify/
+├── __init__.py                 # Module initialization
+├── spotify_mcp.py             # Main MCP server with 17 tools
+├── spotify_oauth_helper.py    # OAuth authentication helper
+├── spotify_token_manager.py   # Automatic token management
+├── spotify_tokens.json        # Stored OAuth tokens (auto-generated)
+├── README.md                  # This file
+└── README_zh.md              # Chinese documentation
+```
+
+## Security Notes
+
+- 🔒 Tokens stored locally in `spotify_tokens.json`
+- 🔄 Access tokens automatically refresh when needed
+- 🚫 Never commit tokens or credentials to version control
+- 🔐 Keep your Client Secret secure and private
+- 🌐 Redirect URI must match exactly between config and Spotify app settings
+
+## Quick Start Example
+
+```bash
+# 1. Test credentials
+test_spotify_credentials()
+
+# 2. Get token status
+get_spotify_token_status()
+
+# 3. Get your profile
+get_current_user_profile()
+
+# 4. Get your top tracks
+get_user_top_items(item_type="tracks", time_range="short_term")
+
+# 5. Get recently played music
+get_user_recently_played()
+```

--- a/platforms/spotify/README_zh.md
+++ b/platforms/spotify/README_zh.md
@@ -1,0 +1,168 @@
+# Spotify 平台集成
+
+此模块为 PersonalHub 提供全面的 Spotify API 集成，允许访问个人音乐数据、偏好和用户交互功能。
+
+## 功能特性
+
+- ✅ **完整的 OAuth2 认证** 与自动令牌刷新
+- ✅ **用户档案和音乐库管理**
+- ✅ **音乐发现** - 热门艺术家、曲目和最近播放
+- ✅ **社交功能** - 关注/取消关注艺术家和播放列表
+- ✅ **音乐库管理** - 收藏的曲目、专辑、播客、单集、有声书
+- ✅ **播放列表操作** - 查看和管理播放列表
+- ✅ **无缝令牌管理** - 无需手动刷新
+
+## 设置步骤
+
+### 1. 创建 Spotify 应用
+
+1. 前往 [Spotify 开发者控制台](https://developer.spotify.com/dashboard)
+2. 创建新应用
+3. 在应用设置中配置重定向 URI
+4. 记录下你的 Client ID 和 Client Secret
+
+### 2. 配置环境变量
+
+在你的配置文件中添加以下内容：
+
+```bash
+# Spotify API 配置
+SPOTIFY_CLIENT_ID=你的客户端ID
+SPOTIFY_CLIENT_SECRET=你的客户端密钥
+SPOTIFY_REDIRECT_URI=https://example.com/callback
+```
+
+### 3. 完成 OAuth 认证
+
+使用 MCP 工具完成 OAuth 认证：
+
+```bash
+# 步骤 1：初始化 OAuth 流程
+setup_spotify_oauth client_id="你的客户端ID" client_secret="你的客户端密钥"
+
+# 步骤 2：访问提供的授权 URL 并授权应用
+# 步骤 3：从回调 URL 中复制授权码
+
+# 步骤 4：完成认证
+complete_spotify_oauth client_id="你的客户端ID" client_secret="你的客户端密钥" authorization_code="你的授权码"
+```
+
+## 可用的 MCP 工具（共 17 个）
+
+### 🔐 认证和配置（7 个工具）
+- `test_spotify_credentials()` - 测试 API 凭据
+- `get_spotify_config()` - 获取配置状态
+- `setup_spotify_oauth(client_id, client_secret, redirect_uri?)` - 初始化 OAuth 流程
+- `complete_spotify_oauth(client_id, client_secret, authorization_code, redirect_uri?)` - 完成 OAuth 认证
+- `refresh_spotify_token()` - 手动刷新访问令牌
+- `auto_refresh_spotify_token_if_needed()` - 根据需要自动刷新
+- `get_spotify_token_status()` - 获取令牌状态信息
+
+### 👤 用户档案（2 个工具）
+- `get_current_user_profile(access_token?)` - 获取当前用户档案
+- `get_user_profile(user_id, access_token?)` - 获取指定用户档案
+
+### 🎵 音乐发现（2 个工具）
+- `get_user_top_items(item_type="tracks", time_range="medium_term", limit=50, access_token?)` - 获取热门艺术家或曲目
+- `get_user_recently_played(limit=50, access_token?)` - 获取最近播放的曲目
+
+### 👥 社交功能（5 个工具）
+- `get_followed_artists(limit=50, access_token?)` - 获取关注的艺术家
+- `follow_artists_or_users(ids, follow_type="artist", access_token?)` - 关注艺术家/用户
+- `unfollow_artists_or_users(ids, follow_type="artist", access_token?)` - 取消关注艺术家/用户
+- `follow_playlist(playlist_id, public=true, access_token?)` - 关注播放列表
+- `unfollow_playlist(playlist_id, access_token?)` - 取消关注播放列表
+
+### 💾 音乐库管理（5 个工具）
+- `get_user_saved_tracks(limit=50, offset=0, access_token?)` - 获取收藏的曲目
+- `get_user_saved_albums(limit=50, offset=0, access_token?)` - 获取收藏的专辑
+- `get_user_saved_shows(limit=50, offset=0, access_token?)` - 获取收藏的播客节目
+- `get_user_saved_episodes(limit=50, offset=0, access_token?)` - 获取收藏的播客单集
+- `get_user_saved_audiobooks(limit=50, offset=0, access_token?)` - 获取收藏的有声书
+
+### 📋 播放列表操作（3 个工具）
+- `get_current_user_playlists(limit=50, offset=0, access_token?)` - 获取当前用户的播放列表
+- `get_user_playlists(user_id, limit=50, offset=0, access_token?)` - 获取用户的公开播放列表
+- `get_playlist_items(playlist_id, limit=100, offset=0, access_token?)` - 获取播放列表内容
+
+## OAuth 权限范围
+
+认证期间自动请求以下权限范围：
+
+**读取权限：**
+- `user-read-private` - 访问用户档案信息
+- `user-read-email` - 访问用户邮箱地址
+- `user-library-read` - 访问用户收藏的内容
+- `user-read-recently-played` - 访问最近播放的曲目
+- `user-top-read` - 访问热门艺术家和曲目
+- `playlist-read-private` - 访问私人播放列表
+- `playlist-read-collaborative` - 访问协作播放列表
+- `user-read-playback-state` - 访问当前播放状态
+- `user-read-currently-playing` - 访问当前播放曲目
+
+**关注权限：**
+- `user-follow-read` - 访问关注的艺术家和用户
+- `user-follow-modify` - 关注/取消关注艺术家和用户的能力
+
+**播放列表权限：**
+- `playlist-modify-public` - 修改公开播放列表的能力
+- `playlist-modify-private` - 修改私人播放列表的能力
+
+## 自动令牌管理
+
+✅ **访问令牌在过期前自动刷新**（约每 55 分钟）
+✅ **刷新令牌有效期 1 年** 并在每次使用时自动延长
+✅ **无需手动干预** - 完全自动化
+✅ **无缝后台操作** - 用户从不会遇到令牌过期
+
+### 仅在以下情况需要重新认证：
+- 刷新令牌过期（约 1 年未使用后）
+- 用户手动撤销应用权限
+- 应用权限/范围被修改
+
+## 默认限制（为最大数据量优化）
+
+所有工具默认使用**最大允许限制**：
+- **大部分 API**：50 项（API 最大值）
+- **播放列表内容**：100 项（API 最大值）
+- **分页**：所有工具都支持 `offset` 参数获取更多数据
+
+## 文件结构
+
+```
+spotify/
+├── __init__.py                 # 模块初始化
+├── spotify_mcp.py             # 主要 MCP 服务器（17 个工具）
+├── spotify_oauth_helper.py    # OAuth 认证助手
+├── spotify_token_manager.py   # 自动令牌管理
+├── spotify_tokens.json        # 存储的 OAuth 令牌（自动生成）
+├── README.md                  # 英文文档
+└── README_zh.md              # 本文件
+```
+
+## 安全注意事项
+
+- 🔒 令牌存储在本地的 `spotify_tokens.json` 文件中
+- 🔄 访问令牌在需要时自动刷新
+- 🚫 切勿将令牌或凭据提交到版本控制系统
+- 🔐 保持你的 Client Secret 安全和私密
+- 🌐 重定向 URI 必须在配置和 Spotify 应用设置中完全匹配
+
+## 快速开始示例
+
+```bash
+# 1. 测试凭据
+test_spotify_credentials()
+
+# 2. 获取令牌状态
+get_spotify_token_status()
+
+# 3. 获取你的档案
+get_current_user_profile()
+
+# 4. 获取你的热门曲目
+get_user_top_items(item_type="tracks", time_range="short_term")
+
+# 5. 获取最近播放的音乐
+get_user_recently_played()
+```

--- a/platforms/spotify/__init__.py
+++ b/platforms/spotify/__init__.py
@@ -1,0 +1,8 @@
+"""
+Spotify Platform Module
+Provides Spotify API integration for personalized music data access.
+"""
+
+from .spotify_mcp import setup_spotify_mcp
+
+__all__ = ['setup_spotify_mcp']

--- a/platforms/spotify/spotify_mcp.py
+++ b/platforms/spotify/spotify_mcp.py
@@ -1,0 +1,697 @@
+"""
+Spotify MCP Server Module
+Provides Spotify API integration for personalized music consumption data.
+"""
+
+import os
+import httpx
+import base64
+from typing import Dict, List, Optional
+from mcp.server.fastmcp import FastMCP
+from .spotify_oauth_helper import SpotifyOAuthHelper
+from .spotify_token_manager import SpotifyTokenManager
+
+# Spotify API configuration
+SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
+SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
+
+def _get_valid_oauth_token(access_token: str = None) -> str:
+    """
+    Get valid OAuth token with unified logic
+    Priority:
+    1. Explicitly passed access_token (if not None and not empty)
+    2. Automatically obtained valid token from token manager (preferred, auto-refresh)
+    3. Token from environment variables (as backup)
+    """
+    # 1. If explicitly passed valid access_token, use it directly
+    if access_token and access_token.strip() and access_token != "null":
+        return access_token
+    
+    # 2. Try to use token manager to get valid token (auto-refresh)
+    try:
+        token_manager = SpotifyTokenManager()
+        managed_token = token_manager.get_valid_access_token()
+        if managed_token:
+            return managed_token
+    except Exception as e:
+        print(f"⚠️ Token manager failed: {e}")
+    
+    # 3. Backup: try to get from environment variables
+    env_token = os.getenv("SPOTIFY_ACCESS_TOKEN")
+    if env_token and env_token.strip():
+        return env_token
+    
+    return None
+
+def _ensure_valid_oauth_token(access_token: str = None) -> tuple[str, dict]:
+    """
+    Ensure valid OAuth token, auto-refresh if needed
+    Returns: (token, status_info)
+    """
+    # First try to get token
+    token = _get_valid_oauth_token(access_token)
+    
+    if not token:
+        return None, {
+            "status": "error",
+            "message": "No valid OAuth token available. Please complete OAuth authentication first."
+        }
+    
+    return token, {"status": "success", "message": "Valid token obtained"}
+
+def setup_spotify_mcp(mcp: FastMCP):
+    """Setup Spotify-related MCP tools and resources."""
+    
+    # Tools - All Spotify functions as callable tools
+    @mcp.tool()
+    def test_spotify_credentials() -> str:
+        """Test Spotify API credentials."""
+        client_id = os.getenv("SPOTIFY_CLIENT_ID")
+        client_secret = os.getenv("SPOTIFY_CLIENT_SECRET")
+        
+        if not client_id or not client_secret:
+            return "❌ Spotify API credentials not found in environment variables"
+        
+        return f"✅ Spotify API credentials found: Client ID={client_id[:8]}..."
+
+    @mcp.tool()
+    def get_spotify_config() -> str:
+        """Get Spotify API configuration status."""
+        client_id = os.getenv("SPOTIFY_CLIENT_ID")
+        client_secret = os.getenv("SPOTIFY_CLIENT_SECRET")
+        access_token = os.getenv("SPOTIFY_ACCESS_TOKEN")
+        
+        config_status = {
+            "client_id": "✅ Set" if client_id else "❌ Not set",
+            "client_secret": "✅ Set" if client_secret else "❌ Not set",
+            "access_token": "✅ Set" if access_token else "❌ Not set"
+        }
+        
+        status_text = "Spotify API Configuration Status:\n"
+        for key, value in config_status.items():
+            status_text += f"- {key}: {value}\n"
+        
+        return status_text
+
+    @mcp.tool()
+    def setup_spotify_oauth(client_id: str, client_secret: str, redirect_uri: str = None) -> dict:
+        """
+        Setup Spotify OAuth2 authentication (initial authentication)
+        
+        Args:
+            client_id: Spotify Client ID
+            client_secret: Spotify Client Secret
+            redirect_uri: Optional redirect URI (defaults to environment variable or http://localhost:8888/callback)
+            
+        Returns:
+            Dictionary containing authentication status and next steps
+        """
+        try:
+            oauth_helper = SpotifyOAuthHelper(client_id, client_secret, redirect_uri)
+            auth_url = oauth_helper.get_authorization_url()
+            
+            return {
+                "status": "success",
+                "message": "Please visit the following URL to authorize the application:",
+                "authorization_url": auth_url,
+                "redirect_uri": oauth_helper.redirect_uri,
+                "next_step": "After authorization, you'll be redirected to a URL with a 'code' parameter. Copy that code and use complete_spotify_oauth function."
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"Failed to setup OAuth: {str(e)}"
+            }
+
+    @mcp.tool()
+    def complete_spotify_oauth(client_id: str, client_secret: str, authorization_code: str, redirect_uri: str = None) -> dict:
+        """
+        Complete Spotify OAuth2 authentication (get tokens)
+        
+        Args:
+            client_id: Spotify Client ID
+            client_secret: Spotify Client Secret
+            authorization_code: Authorization code from Spotify callback
+            redirect_uri: Optional redirect URI (should match the one used in setup_spotify_oauth)
+            
+        Returns:
+            Authentication completion status
+        """
+        try:
+            oauth_helper = SpotifyOAuthHelper(client_id, client_secret, redirect_uri)
+            tokens = oauth_helper.exchange_code_for_tokens(authorization_code)
+            
+            # Save tokens using token manager
+            token_manager = SpotifyTokenManager()
+            token_manager.save_tokens(tokens)
+            
+            return {
+                "status": "success",
+                "message": "✅ Spotify OAuth authentication completed successfully!",
+                "tokens_saved": True
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"Failed to complete OAuth: {str(e)}"
+            }
+
+    @mcp.tool()
+    def refresh_spotify_token() -> dict:
+        """Manually refresh Spotify access token"""
+        try:
+            token_manager = SpotifyTokenManager()
+            new_token = token_manager.refresh_access_token()
+            
+            if new_token:
+                return {
+                    "status": "success", 
+                    "message": "✅ Spotify access token refreshed successfully"
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": "❌ Failed to refresh token. Please re-authenticate."
+                }
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"Token refresh failed: {str(e)}"
+            }
+
+    @mcp.tool()
+    def auto_refresh_spotify_token_if_needed() -> dict:
+        """Auto check and refresh Spotify access token if needed"""
+        try:
+            token_manager = SpotifyTokenManager()
+            result = token_manager.ensure_valid_token()
+            
+            return {
+                "status": "success",
+                "message": f"✅ Token status: {result['message']}",
+                "token_refreshed": result.get('refreshed', False)
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"Auto refresh failed: {str(e)}"
+            }
+
+    @mcp.tool()
+    def get_spotify_token_status() -> dict:
+        """Get Spotify token status information"""
+        try:
+            token_manager = SpotifyTokenManager()
+            status = token_manager.get_token_status()
+            
+            return {
+                "status": "success",
+                "token_info": status
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "message": f"Failed to get token status: {str(e)}"
+            }
+
+    # User Profile APIs
+    @mcp.tool()
+    def get_current_user_profile(access_token: str = None) -> dict:
+        """Get current user's Spotify profile information."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me", headers=headers)
+                response.raise_for_status()
+                user_data = response.json()
+                
+                return {
+                    "status": "success",
+                    "user_profile": {
+                        "id": user_data.get("id"),
+                        "display_name": user_data.get("display_name"),
+                        "email": user_data.get("email"),
+                        "country": user_data.get("country"),
+                        "followers": user_data.get("followers", {}).get("total", 0),
+                        "product": user_data.get("product"),
+                        "images": user_data.get("images", []),
+                        "external_urls": user_data.get("external_urls", {})
+                    }
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get user profile: {e}"}
+
+    @mcp.tool()
+    def get_user_profile(user_id: str, access_token: str = None) -> dict:
+        """Get a specific user's public Spotify profile information."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            with httpx.Client() as client:
+                response = client.get(f"https://api.spotify.com/v1/users/{user_id}", headers=headers)
+                response.raise_for_status()
+                user_data = response.json()
+                
+                return {
+                    "status": "success",
+                    "user_profile": {
+                        "id": user_data.get("id"),
+                        "display_name": user_data.get("display_name"),
+                        "followers": user_data.get("followers", {}).get("total", 0),
+                        "images": user_data.get("images", []),
+                        "external_urls": user_data.get("external_urls", {})
+                    }
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get user profile: {e}"}
+
+    @mcp.tool()
+    def get_user_top_items(item_type: str = "tracks", time_range: str = "medium_term", limit: int = 50, access_token: str = None) -> dict:
+        """Get user's top artists or tracks.
+        
+        Args:
+            item_type: "artists" or "tracks"
+            time_range: "short_term" (4 weeks), "medium_term" (6 months), "long_term" (years)
+            limit: Number of items to return (1-50, default 50)
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        if item_type not in ["artists", "tracks"]:
+            return {"status": "error", "message": "item_type must be 'artists' or 'tracks'"}
+        
+        if time_range not in ["short_term", "medium_term", "long_term"]:
+            return {"status": "error", "message": "time_range must be 'short_term', 'medium_term', or 'long_term'"}
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"time_range": time_range, "limit": min(limit, 50)}
+            
+            with httpx.Client() as client:
+                response = client.get(f"https://api.spotify.com/v1/me/top/{item_type}", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "item_type": item_type,
+                    "time_range": time_range,
+                    "total": data.get("total"),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get top {item_type}: {e}"}
+
+    # Follow/Unfollow APIs
+    @mcp.tool()
+    def get_followed_artists(limit: int = 50, access_token: str = None) -> dict:
+        """Get user's followed artists."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"type": "artist", "limit": min(limit, 50)}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/following", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("artists", {}).get("total", 0),
+                    "artists": data.get("artists", {}).get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get followed artists: {e}"}
+
+    @mcp.tool()
+    def follow_artists_or_users(ids: str, follow_type: str = "artist", access_token: str = None) -> dict:
+        """Follow artists or users.
+        
+        Args:
+            ids: Comma-separated list of artist or user IDs
+            follow_type: "artist" or "user"
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        if follow_type not in ["artist", "user"]:
+            return {"status": "error", "message": "follow_type must be 'artist' or 'user'"}
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+            params = {"type": follow_type, "ids": ids}
+            
+            with httpx.Client() as client:
+                response = client.put("https://api.spotify.com/v1/me/following", headers=headers, params=params)
+                response.raise_for_status()
+                
+                return {
+                    "status": "success",
+                    "message": f"Successfully followed {follow_type}s: {ids}"
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to follow {follow_type}s: {e}"}
+
+    @mcp.tool()
+    def unfollow_artists_or_users(ids: str, follow_type: str = "artist", access_token: str = None) -> dict:
+        """Unfollow artists or users.
+        
+        Args:
+            ids: Comma-separated list of artist or user IDs
+            follow_type: "artist" or "user"
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        if follow_type not in ["artist", "user"]:
+            return {"status": "error", "message": "follow_type must be 'artist' or 'user'"}
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+            params = {"type": follow_type, "ids": ids}
+            
+            with httpx.Client() as client:
+                response = client.delete("https://api.spotify.com/v1/me/following", headers=headers, params=params)
+                response.raise_for_status()
+                
+                return {
+                    "status": "success",
+                    "message": f"Successfully unfollowed {follow_type}s: {ids}"
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to unfollow {follow_type}s: {e}"}
+
+    @mcp.tool()
+    def follow_playlist(playlist_id: str, public: bool = True, access_token: str = None) -> dict:
+        """Follow a playlist.
+        
+        Args:
+            playlist_id: Spotify playlist ID
+            public: Whether the playlist will be included in user's public playlists
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+            data = {"public": public}
+            
+            with httpx.Client() as client:
+                response = client.put(f"https://api.spotify.com/v1/playlists/{playlist_id}/followers", 
+                                    headers=headers, json=data)
+                response.raise_for_status()
+                
+                return {
+                    "status": "success",
+                    "message": f"Successfully followed playlist: {playlist_id}"
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to follow playlist: {e}"}
+
+    @mcp.tool()
+    def unfollow_playlist(playlist_id: str, access_token: str = None) -> dict:
+        """Unfollow a playlist.
+        
+        Args:
+            playlist_id: Spotify playlist ID
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            
+            with httpx.Client() as client:
+                response = client.delete(f"https://api.spotify.com/v1/playlists/{playlist_id}/followers", headers=headers)
+                response.raise_for_status()
+                
+                return {
+                    "status": "success",
+                    "message": f"Successfully unfollowed playlist: {playlist_id}"
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to unfollow playlist: {e}"}
+
+    # User's Saved Content APIs
+    @mcp.tool()
+    def get_user_saved_tracks(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get user's saved tracks."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/tracks", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get saved tracks: {e}"}
+
+    @mcp.tool()
+    def get_user_saved_albums(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get user's saved albums."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/albums", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get saved albums: {e}"}
+
+    @mcp.tool()
+    def get_user_saved_shows(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get user's saved podcast shows."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/shows", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get saved shows: {e}"}
+
+    @mcp.tool()
+    def get_user_saved_episodes(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get user's saved podcast episodes."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/episodes", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get saved episodes: {e}"}
+
+    @mcp.tool()
+    def get_user_saved_audiobooks(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get user's saved audiobooks."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/audiobooks", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get saved audiobooks: {e}"}
+
+    # Playlist APIs
+    @mcp.tool()
+    def get_current_user_playlists(limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get current user's playlists."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/playlists", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get user playlists: {e}"}
+
+    @mcp.tool()
+    def get_user_playlists(user_id: str, limit: int = 50, offset: int = 0, access_token: str = None) -> dict:
+        """Get a user's public playlists."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get(f"https://api.spotify.com/v1/users/{user_id}/playlists", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "user_id": user_id,
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get user playlists: {e}"}
+
+    @mcp.tool()
+    def get_playlist_items(playlist_id: str, limit: int = 100, offset: int = 0, access_token: str = None) -> dict:
+        """Get items (tracks/episodes) in a playlist."""
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50), "offset": offset}
+            
+            with httpx.Client() as client:
+                response = client.get(f"https://api.spotify.com/v1/playlists/{playlist_id}/tracks", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                return {
+                    "status": "success",
+                    "playlist_id": playlist_id,
+                    "total": data.get("total", 0),
+                    "items": data.get("items", [])
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get playlist items: {e}"}
+
+    # Recently Played API
+    @mcp.tool()
+    def get_user_recently_played(limit: int = 50, access_token: str = None) -> dict:
+        """Get user's recently played tracks.
+        
+        Args:
+            limit: Number of tracks to return (1-50, default 50)
+        """
+        token, status = _ensure_valid_oauth_token(access_token)
+        if not token:
+            return status
+        
+        try:
+            headers = {"Authorization": f"Bearer {token}"}
+            params = {"limit": min(limit, 50)}
+            
+            with httpx.Client() as client:
+                response = client.get("https://api.spotify.com/v1/me/player/recently-played", headers=headers, params=params)
+                response.raise_for_status()
+                data = response.json()
+                
+                # Format the response for better readability
+                items = data.get("items", [])
+                formatted_tracks = []
+                
+                for item in items:
+                    track = item.get("track", {})
+                    artists = ", ".join([artist.get("name", "") for artist in track.get("artists", [])])
+                    
+                    formatted_track = {
+                        "track_name": track.get("name", "Unknown"),
+                        "artists": artists,
+                        "album": track.get("album", {}).get("name", "Unknown"),
+                        "played_at": item.get("played_at", ""),
+                        "duration_ms": track.get("duration_ms", 0),
+                        "external_urls": track.get("external_urls", {}),
+                        "track_id": track.get("id", "")
+                    }
+                    formatted_tracks.append(formatted_track)
+                
+                return {
+                    "status": "success",
+                    "total_tracks": len(formatted_tracks),
+                    "tracks": formatted_tracks,
+                    "next": data.get("next"),
+                    "cursors": data.get("cursors", {})
+                }
+        except httpx.HTTPError as e:
+            return {"status": "error", "message": f"Failed to get recently played tracks: {e}"}
+
+    print("✅ Spotify MCP tools registered successfully")

--- a/platforms/spotify/spotify_oauth_helper.py
+++ b/platforms/spotify/spotify_oauth_helper.py
@@ -1,0 +1,90 @@
+"""
+Spotify OAuth Helper
+Handles Spotify OAuth2 authentication flow.
+"""
+
+import os
+import httpx
+import base64
+import urllib.parse
+from typing import Dict, Optional
+
+class SpotifyOAuthHelper:
+    """Helper class for Spotify OAuth2 authentication."""
+    
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str = None):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        # Use provided redirect_uri, or get from environment, or use default
+        self.redirect_uri = redirect_uri or os.getenv("SPOTIFY_REDIRECT_URI", "http://localhost:8888/callback")
+        self.scope = "user-read-private user-read-email user-library-read user-read-recently-played user-top-read playlist-read-private playlist-read-collaborative user-read-playback-state user-read-currently-playing user-follow-read user-follow-modify playlist-modify-public playlist-modify-private"
+        
+    def get_authorization_url(self) -> str:
+        """Generate Spotify authorization URL."""
+        auth_url = "https://accounts.spotify.com/authorize"
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "scope": self.scope,
+            "show_dialog": "true"
+        }
+        
+        # Build URL with parameters
+        param_string = "&".join([f"{key}={urllib.parse.quote(str(value))}" for key, value in params.items()])
+        return f"{auth_url}?{param_string}"
+    
+    def exchange_code_for_tokens(self, authorization_code: str) -> Dict:
+        """Exchange authorization code for access and refresh tokens."""
+        token_url = "https://accounts.spotify.com/api/token"
+        
+        # Prepare authorization header
+        auth_string = f"{self.client_id}:{self.client_secret}"
+        auth_bytes = auth_string.encode("ascii")
+        auth_b64 = base64.b64encode(auth_bytes).decode("ascii")
+        
+        headers = {
+            "Authorization": f"Basic {auth_b64}",
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        
+        data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": self.redirect_uri
+        }
+        
+        try:
+            with httpx.Client() as client:
+                response = client.post(token_url, headers=headers, data=data)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            raise Exception(f"Failed to exchange code for tokens: {e}")
+    
+    def refresh_access_token(self, refresh_token: str) -> Dict:
+        """Refresh access token using refresh token."""
+        token_url = "https://accounts.spotify.com/api/token"
+        
+        # Prepare authorization header
+        auth_string = f"{self.client_id}:{self.client_secret}"
+        auth_bytes = auth_string.encode("ascii")
+        auth_b64 = base64.b64encode(auth_bytes).decode("ascii")
+        
+        headers = {
+            "Authorization": f"Basic {auth_b64}",
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token
+        }
+        
+        try:
+            with httpx.Client() as client:
+                response = client.post(token_url, headers=headers, data=data)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            raise Exception(f"Failed to refresh access token: {e}")

--- a/platforms/spotify/spotify_token_manager.py
+++ b/platforms/spotify/spotify_token_manager.py
@@ -1,0 +1,155 @@
+"""
+Spotify Token Manager
+Manages Spotify OAuth tokens with automatic refresh capabilities.
+"""
+
+import os
+import json
+import time
+from pathlib import Path
+from typing import Dict, Optional
+from .spotify_oauth_helper import SpotifyOAuthHelper
+
+class SpotifyTokenManager:
+    """Manages Spotify OAuth tokens with automatic refresh."""
+    
+    def __init__(self):
+        self.token_file = Path(__file__).parent / "spotify_tokens.json"
+        self.client_id = os.getenv("SPOTIFY_CLIENT_ID")
+        self.client_secret = os.getenv("SPOTIFY_CLIENT_SECRET")
+    
+    def save_tokens(self, tokens: Dict) -> None:
+        """Save tokens to file with expiration time."""
+        # Add expiration timestamp
+        if "expires_in" in tokens:
+            tokens["expires_at"] = time.time() + tokens["expires_in"]
+        
+        try:
+            with open(self.token_file, "w") as f:
+                json.dump(tokens, f, indent=2)
+            print(f"✅ Tokens saved to {self.token_file}")
+        except Exception as e:
+            print(f"❌ Failed to save tokens: {e}")
+            raise
+    
+    def load_tokens(self) -> Optional[Dict]:
+        """Load tokens from file."""
+        if not self.token_file.exists():
+            return None
+        
+        try:
+            with open(self.token_file, "r") as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"❌ Failed to load tokens: {e}")
+            return None
+    
+    def is_token_expired(self, tokens: Dict) -> bool:
+        """Check if access token is expired."""
+        if "expires_at" not in tokens:
+            return True
+        
+        # Consider token expired if it expires within 5 minutes
+        return time.time() >= (tokens["expires_at"] - 300)
+    
+    def refresh_access_token(self) -> Optional[str]:
+        """Refresh access token using refresh token."""
+        tokens = self.load_tokens()
+        if not tokens or "refresh_token" not in tokens:
+            print("❌ No refresh token available")
+            return None
+        
+        if not self.client_id or not self.client_secret:
+            print("❌ Spotify client credentials not configured")
+            return None
+        
+        try:
+            oauth_helper = SpotifyOAuthHelper(self.client_id, self.client_secret)
+            new_tokens = oauth_helper.refresh_access_token(tokens["refresh_token"])
+            
+            # Update tokens (preserve refresh_token if not returned)
+            if "refresh_token" not in new_tokens and "refresh_token" in tokens:
+                new_tokens["refresh_token"] = tokens["refresh_token"]
+            
+            self.save_tokens(new_tokens)
+            print("✅ Access token refreshed successfully")
+            return new_tokens["access_token"]
+        
+        except Exception as e:
+            print(f"❌ Failed to refresh access token: {e}")
+            return None
+    
+    def get_valid_access_token(self) -> Optional[str]:
+        """Get valid access token, refresh if necessary."""
+        tokens = self.load_tokens()
+        if not tokens:
+            return None
+        
+        # Check if token is expired
+        if self.is_token_expired(tokens):
+            print("🔄 Access token expired, refreshing...")
+            return self.refresh_access_token()
+        
+        return tokens.get("access_token")
+    
+    def ensure_valid_token(self) -> Dict:
+        """Ensure we have a valid token, refresh if needed."""
+        tokens = self.load_tokens()
+        if not tokens:
+            return {
+                "status": "error",
+                "message": "No tokens found. Please authenticate first."
+            }
+        
+        if self.is_token_expired(tokens):
+            new_token = self.refresh_access_token()
+            if new_token:
+                return {
+                    "status": "success",
+                    "message": "Token refreshed successfully",
+                    "refreshed": True
+                }
+            else:
+                return {
+                    "status": "error",
+                    "message": "Failed to refresh token. Please re-authenticate."
+                }
+        else:
+            return {
+                "status": "success",
+                "message": "Token is still valid",
+                "refreshed": False
+            }
+    
+    def get_token_status(self) -> Dict:
+        """Get current token status information."""
+        tokens = self.load_tokens()
+        if not tokens:
+            return {
+                "has_tokens": False,
+                "message": "No tokens found"
+            }
+        
+        has_access_token = "access_token" in tokens
+        has_refresh_token = "refresh_token" in tokens
+        is_expired = self.is_token_expired(tokens)
+        
+        status = {
+            "has_tokens": True,
+            "has_access_token": has_access_token,
+            "has_refresh_token": has_refresh_token,
+            "is_expired": is_expired
+        }
+        
+        if "expires_at" in tokens:
+            remaining_time = tokens["expires_at"] - time.time()
+            status["expires_in_seconds"] = max(0, int(remaining_time))
+            status["expires_in_minutes"] = max(0, int(remaining_time / 60))
+        
+        return status
+    
+    def clear_tokens(self) -> None:
+        """Clear saved tokens."""
+        if self.token_file.exists():
+            self.token_file.unlink()
+            print("✅ Tokens cleared")

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from platforms.steam.steam_mcp import setup_steam_mcp
 from platforms.youtube.youtube_mcp import setup_youtube_mcp
 from platforms.bilibili.bilibili_mcp import setup_bilibili_mcp
+from platforms.spotify.spotify_mcp import setup_spotify_mcp
 
 # Create main MCP server
 mcp = FastMCP("PersonalHub")
@@ -38,8 +39,10 @@ def setup_all_platforms():
     # Bilibili integration
     setup_bilibili_mcp(mcp)
     
+    # Spotify integration
+    setup_spotify_mcp(mcp)
+    
     # Future platform integrations can be added here:
-    # setup_spotify_mcp(mcp)
     # setup_twitter_mcp(mcp)
     # setup_github_mcp(mcp)
 
@@ -49,23 +52,25 @@ def get_personalization_status() -> str:
     steam_configured = bool(os.getenv("STEAM_API_KEY") and os.getenv("STEAM_USER_ID"))
     youtube_configured = bool(os.getenv("YOUTUBE_API_KEY"))
     bilibili_configured = bool(os.getenv("BILIBILI_SESSDATA") and os.getenv("BILIBILI_BILI_JCT"))
+    spotify_configured = bool(os.getenv("SPOTIFY_CLIENT_ID") and os.getenv("SPOTIFY_CLIENT_SECRET"))
     
     status_info = f"""PersonalHub Server Status:
 
 🎮 Steam Integration: {'✅ Active' if steam_configured else '❌ Not configured'}
 🎥 YouTube Integration: {'✅ Active' if youtube_configured else '❌ Not configured'}
 📺 Bilibili Integration: {'✅ Active' if bilibili_configured else '❌ Not configured'}
-🎵 Spotify Integration: ⏳ Coming soon
+🎵 Spotify Integration: {'✅ Active' if spotify_configured else '❌ Not configured'}
 🐦 Twitter Integration: ⏳ Coming soon
 💻 GitHub Integration: ⏳ Coming soon
 
-Server Version: 1.2.0
-Total Platforms: {sum([steam_configured, youtube_configured, bilibili_configured])} active, 3 planned
+Server Version: 1.3.0
+Total Platforms: {sum([steam_configured, youtube_configured, bilibili_configured, spotify_configured])} active, 2 planned
 
 Configuration Status:
 - Steam API: {'Ready' if steam_configured else 'Needs setup'}
 - YouTube API: {'Ready' if youtube_configured else 'Needs setup'}
 - Bilibili API: {'Ready' if bilibili_configured else 'Needs setup'}
+- Spotify API: {'Ready' if spotify_configured else 'Needs setup'}
 """
     return status_info
 


### PR DESCRIPTION
- 添加 Spotify OAuth2 认证和自动令牌管理
- 实现 17 个 Spotify MCP 工具（用户档案、音乐库、播放列表等）
- 更新主 README 和中文 README 文档
- 添加完整的双语平台文档
- 优化默认 limit 参数为最大值
- 集成到主服务器，支持 4 个平台统一管理